### PR TITLE
Set up Dependabot for project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This commit sets up Dependabot for the project by modifying the `dependabot.yml` file. The configuration file is set to use the second version of the Dependabot configuration syntax, as indicated by the `version: 2` line. The `updates` section, which specifies which package ecosystems to update and where the package manifests are located, is currently left blank and will need to be filled in later. The `schedule` section is set to have Dependabot check for updates on a weekly basis.